### PR TITLE
fix: update actions/checkout version to v7.0.0 in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         hugo-preproc-version: [v1.2.0, v2.0.0]
     steps:
     - name: Checkout
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup hugo-preproc
       uses: ./


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `actions/checkout` action in the `.github/workflows/test.yml` file.

**CI/CD dependency update:**

* Updated `actions/checkout` from version `v4.1.7` to `v7.0.0` to ensure compatibility with the latest GitHub Actions features and security improvements.